### PR TITLE
Use a `cdylib` crate type instead of `bin` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "rocket"
 version = "1.0.0"
 authors = ["Adolfo Ochagavía <aochagavia92@gmail.com>"]
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 clippy = { version = "0.0.118", optional = true }
 itertools-num = "0.1.1"

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ script requires python 2.7 and `wasm-gc`.
 After setting things up, you should be able to compile the code using the commands below:
 
 ```
-cargo buld --release --target wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown
 python post_build.py
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,5 +109,3 @@ pub extern "C" fn toggle_turn_right(b: bool) {
     let data = &mut DATA.lock().unwrap();
     data.actions.rotate_right = b;
 }
-
-pub fn main() {}


### PR DESCRIPTION
This way it avoids the need for `pub fn main() {}` and can help remove some
cruft from the standard library as well!